### PR TITLE
[feat][#25] statsD, prometheus, grafana 구축

### DIFF
--- a/.gitIgnore
+++ b/.gitIgnore
@@ -162,3 +162,6 @@ logs/
 data/*
 env/
 flask-api/config.py
+prometheus/data/
+grafana/
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -76,6 +76,11 @@ x-airflow-common: &airflow-common
     AIRFLOW__WEBSERVER__PAGE_SIZE: 50  # default 100
     AIRFLOW__WEBSERVER__WORKER_REFRESH_INTERVAL: 1800  # default 30
     AIRFLOW__WEBSERVER__WEB_SERVER_WORKER_TIMEOUT: 300  # default 120
+    # Monitoring - StatsD
+    AIRFLOW__METRICS__STATSD_ON: 'True'
+    AIRFLOW__METRICS__STATSD_HOST: 'statsd-exporter' 
+    AIRFLOW__METRICS__STATSD_PORT: 8125
+    AIRFLOW__METRICS__STATSD_PREFIX: 'airflow'
     # WARNING: Use _PIP_ADDITIONAL_REQUIREMENTS option ONLY for a quick checks
     # for other purpose (development, test and especially production usage) build/extend Airflow image.
     _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
@@ -333,6 +338,40 @@ services:
     ports:
       - 4444:4444
     restart: always
+
+  statsd-exporter:
+    image: prom/statsd-exporter
+    container_name: statsd-exporter
+    command: "--statsd.listen-udp=:8125 --web.listen-address=:9102 --statsd.mapping-config=/tmp/statsd_mapping.conf"
+    ports:
+      - 9102:9102
+      - 8125:8125/udp
+    volumes:
+      - ./statsd_mapping.conf:/tmp/statsd_mapping.conf
+    
+  prometheus:
+    image: prom/prometheus
+    container_name: airflow-prometheus
+    ports:
+        - 9092:9090
+    volumes:
+        - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+        - ./prometheus/data:/prometheus
+  
+  grafana:
+    image: grafana/grafana:latest
+    container_name: airflow-grafana
+    depends_on:
+      - prometheus
+    environment:
+      GF_SECURITY_ADMIN_USER: grafana
+      GF_SECURITY_ADMIN_PASSWORD: grafana
+      GF_PATHS_PROVISIONG: /etc/grafana/provisioning
+    ports:
+      - 3000:3000
+    volumes:
+      - ./grafana/data:/var/lib/grafana
+      - ./grafana/provisioning:/grafana/provisioning
 
 volumes:
   postgres-db-volume:

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 30s
+  scrape_timeout: 10s
+
+scrape_configs:
+  - job_name: 'airflow'
+    static_configs:
+      - targets: ['statsd-exporter:9102']
+        labels:
+          airflow_id: 'airflow'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ selenium == 4.10.0
 webdriver_manager == 3.8.6
 slack_sdk
 boto3
+apache-airflow[statsd]

--- a/statsd_mapping.conf
+++ b/statsd_mapping.conf
@@ -1,0 +1,265 @@
+# from https://github.com/databand-ai/airflow-dashboards/blob/main/statsd/statsd.conf
+mappings:
+  # Airflow StatsD metrics mappings (https://airflow.apache.org/docs/apache-airflow/stable/logging-monitoring/metrics.html)
+  # === Counters ===
+  - match: "(.+)\\.(.+)_start$"
+    match_metric_type: counter
+    name: "af_agg_job_start"
+    match_type: regex
+    labels:
+      airflow_id: "$1"
+      job_name: "$2"
+  - match: "(.+)\\.(.+)_end$"
+    match_metric_type: counter
+    name: "af_agg_job_end"
+    match_type: regex
+    labels:
+      airflow_id: "$1"
+      job_name: "$2"
+  - match: "(.+)\\.operator_failures_(.+)$"
+    match_metric_type: counter
+    name: "af_agg_operator_failures"
+    match_type: regex
+    labels:
+      airflow_id: "$1"
+      operator_name: "$2"
+  - match: "(.+)\\.operator_successes_(.+)$"
+    match_metric_type: counter
+    name: "af_agg_operator_successes"
+    match_type: regex
+    labels:
+      airflow_id: "$1"
+      operator_name: "$2"
+  - match: "*.ti_failures"
+    match_metric_type: counter
+    name: "af_agg_ti_failures"
+    labels:
+      airflow_id: "$1"
+  - match: "*.ti_successes"
+    match_metric_type: counter
+    name: "af_agg_ti_successes"
+    labels:
+      airflow_id: "$1"
+  - match: "*.zombies_killed"
+    match_metric_type: counter
+    name: "af_agg_zombies_killed"
+    labels:
+      airflow_id: "$1"
+  - match: "*.scheduler_heartbeat"
+    match_metric_type: counter
+    name: "af_agg_scheduler_heartbeat"
+    labels:
+      airflow_id: "$1"
+  - match: "*.dag_processing.processes"
+    match_metric_type: counter
+    name: "af_agg_dag_processing_processes"
+    labels:
+      airflow_id: "$1"
+  - match: "*.scheduler.tasks.killed_externally"
+    match_metric_type: counter
+    name: "af_agg_scheduler_tasks_killed_externally"
+    labels:
+      airflow_id: "$1"
+  - match: "*.scheduler.tasks.running"
+    match_metric_type: counter
+    name: "af_agg_scheduler_tasks_running"
+    labels:
+      airflow_id: "$1"
+  - match: "*.scheduler.tasks.starving"
+    match_metric_type: counter
+    name: "af_agg_scheduler_tasks_starving"
+    labels:
+      airflow_id: "$1"
+  - match: "*.scheduler.orphaned_tasks.cleared"
+    match_metric_type: counter
+    name: "af_agg_scheduler_orphaned_tasks_cleared"
+    labels:
+      airflow_id: "$1"
+  - match: "*.scheduler.orphaned_tasks.adopted"
+    match_metric_type: counter
+    name: "af_agg_scheduler_orphaned_tasks_adopted"
+    labels:
+      airflow_id: "$1"
+  - match: "*.scheduler.critical_section_busy"
+    match_metric_type: counter
+    name: "af_agg_scheduler_critical_section_busy"
+    labels:
+      airflow_id: "$1"
+  - match: "*.sla_email_notification_failure"
+    match_metric_type: counter
+    name: "af_agg_sla_email_notification_failure"
+    labels:
+      airflow_id: "$1"
+  - match: "*.ti.start.*.*"
+    match_metric_type: counter
+    name: "af_agg_ti_start"
+    labels:
+      airflow_id: "$1"
+      dag_id: "$2"
+      task_id: "$3"
+  - match: "*.ti.finish.*.*.*"
+    match_metric_type: counter
+    name: "af_agg_ti_finish"
+    labels:
+      airflow_id: "$1"
+      dag_id: "$2"
+      task_id: "$3"
+      state: "$4"
+  - match: "*.dag.callback_exceptions"
+    match_metric_type: counter
+    name: "af_agg_dag_callback_exceptions"
+    labels:
+      airflow_id: "$1"
+  - match: "*.celery.task_timeout_error"
+    match_metric_type: counter
+    name: "af_agg_celery_task_timeout_error"
+    labels:
+      airflow_id: "$1"
+
+  # === Gauges ===
+  - match: "*.dagbag_size"
+    match_metric_type: gauge
+    name: "af_agg_dagbag_size"
+    labels:
+      airflow_id: "$1"
+  - match: "*.dag_processing.import_errors"
+    match_metric_type: gauge
+    name: "af_agg_dag_processing_import_errors"
+    labels:
+      airflow_id: "$1"
+  - match: "*.dag_processing.total_parse_time"
+    match_metric_type: gauge
+    name: "af_agg_dag_processing_total_parse_time"
+    labels:
+      airflow_id: "$1"
+  - match: "*.dag_processing.last_runtime.*"
+    match_metric_type: gauge
+    name: "af_agg_dag_processing_last_runtime"
+    labels:
+      airflow_id: "$1"
+      dag_file: "$2"
+  - match: "*.dag_processing.last_run.seconds_ago.*"
+    match_metric_type: gauge
+    name: "af_agg_dag_processing_last_run_seconds"
+    labels:
+      airflow_id: "$1"
+      dag_file: "$2"
+  - match: "*.dag_processing.processor_timeouts"
+    match_metric_type: gauge
+    name: "af_agg_dag_processing_processor_timeouts"
+    labels:
+      airflow_id: "$1"
+  - match: "*.executor.open_slots"
+    match_metric_type: gauge
+    name: "af_agg_executor_open_slots"
+    labels:
+      airflow_id: "$1"
+  - match: "*.executor.queued_tasks"
+    match_metric_type: gauge
+    name: "af_agg_executor_queued_tasks"
+    labels:
+      airflow_id: "$1"
+  - match: "*.executor.running_tasks"
+    match_metric_type: gauge
+    name: "af_agg_executor_running_tasks"
+    labels:
+      airflow_id: "$1"
+  - match: "*.pool.open_slots.*"
+    match_metric_type: gauge
+    name: "af_agg_pool_open_slots"
+    labels:
+      airflow_id: "$1"
+      pool_name: "$2"
+  - match: "*.pool.queued_slots.*"
+    match_metric_type: gauge
+    name: "af_agg_pool_queued_slots"
+    labels:
+      airflow_id: "$1"
+      pool_name: "$2"
+  - match: "*.pool.running_slots.*"
+    match_metric_type: gauge
+    name: "af_agg_pool_running_slots"
+    labels:
+      airflow_id: "$1"
+      pool_name: "$2"
+  - match: "*.pool.starving_tasks.*"
+    match_metric_type: gauge
+    name: "af_agg_pool_starving_tasks"
+    labels:
+      airflow_id: "$1"
+      pool_name: "$2"
+  - match: "*.smart_sensor_operator.poked_tasks"
+    match_metric_type: gauge
+    name: "af_agg_smart_sensor_operator_poked_tasks"
+    labels:
+      airflow_id: "$1"
+  - match: "*.smart_sensor_operator.poked_success"
+    match_metric_type: gauge
+    name: "af_agg_smart_sensor_operator_poked_success"
+    labels:
+      airflow_id: "$1"
+  - match: "*.smart_sensor_operator.poked_exception"
+    match_metric_type: gauge
+    name: "af_agg_smart_sensor_operator_poked_exception"
+    labels:
+      airflow_id: "$1"
+  - match: "*.smart_sensor_operator.exception_failures"
+    match_metric_type: gauge
+    name: "af_agg_smart_sensor_operator_exception_failures"
+    labels:
+      airflow_id: "$1"
+  - match: "*.smart_sensor_operator.infra_failures"
+    match_metric_type: gauge
+    name: "af_agg_smart_sensor_operator_infra_failures"
+    labels:
+      airflow_id: "$1"
+
+  # === Timers ===
+  - match: "*.dagrun.dependency-check.*"
+    match_metric_type: observer
+    name: "af_agg_dagrun_dependency_check"
+    labels:
+      airflow_id: "$1"
+      dag_id: "$2"
+  - match: "*.dag.*.*.duration"
+    match_metric_type: observer
+    name: "af_agg_dag_task_duration"
+    labels:
+      airflow_id: "$1"
+      dag_id: "$2"
+      task_id: "$3"
+  - match: "*.dag_processing.last_duration.*"
+    match_metric_type: observer
+    name: "af_agg_dag_processing_duration"
+    labels:
+      airflow_id: "$1"
+      dag_file: "$2"
+  - match: "*.dagrun.duration.success.*"
+    match_metric_type: observer
+    name: "af_agg_dagrun_duration_success"
+    labels:
+      airflow_id: "$1"
+      dag_id: "$2"
+  - match: "*.dagrun.duration.failed.*"
+    match_metric_type: observer
+    name: "af_agg_dagrun_duration_failed"
+    labels:
+      airflow_id: "$1"
+      dag_id: "$2"
+  - match: "*.dagrun.schedule_delay.*"
+    match_metric_type: observer
+    name: "af_agg_dagrun_schedule_delay"
+    labels:
+      airflow_id: "$1"
+      dag_id: "$2"
+  - match: "*.scheduler.critical_section_duration"
+    match_metric_type: observer
+    name: "af_agg_scheduler_critical_section_duration"
+    labels:
+      airflow_id: "$1"
+  - match: "*.dagrun.*.first_task_scheduling_delay"
+    match_metric_type: observer
+    name: "af_agg_dagrun_first_task_scheduling_delay"
+    labels:
+      airflow_id: "$1"
+      dag_id: "$2"


### PR DESCRIPTION
## 작업 내용
작업 내용 간략 설명 

[feat][#25] statsD, prometheus, grafana 구축

- statsD (Airflow Metric 전송) 설정
- Prometheus(statsD로부터 받은 Metric 저장하는 시계열 데이터베이스) 구축 및 연결
- Grafana 대시보드 생성 (Prometheus에서 데이터를 불러와 시각화)
  
## 시급한 정도
- [ ] 🏃‍♂️ 급함 : 최대한 빠르게 리뷰 부탁드립니다.
- [x] 🚶 보통 : 9/1일 정오까지 리뷰 부탁드립니다.
- [ ]  🐢 천천히 : 급하지 않습니다. m/n일 까지 리뷰 부탁드립니다.

## 참고 사항
PR 시 중점적으로 봐주었으면 하는 부분이나 참고 사항을 적어주세요.
docker-compose 파일 위주로 변경되었습니다.
